### PR TITLE
Handle null keys in log format

### DIFF
--- a/src/trx_ct.erl
+++ b/src/trx_ct.erl
@@ -35,7 +35,11 @@ parse(Log) ->
             || Line <- re:split(Log, "^=", [unicode, multiline]),
                 nomatch =:= string:prefix(Line, "=="),
                 not string:equal(Line, "")],
-    group_log_data(Data).
+    group_log_data([case T of
+                        {K} -> {K, <<"">>}; % default
+                        {K,V} -> {K, V}
+                    end || T <- Data]).
+
 
 generate_trx(Data, RunDir) ->
     {Global, AllCases} = merge_data(Data),


### PR DESCRIPTION
When running in some environments, such as a minimal docker container,
the log format for a test run has arguments that look like:

    === Starting test, 0 test cases
    =cases         0
    =user
    =host          nohost
    =hosts         nohost
    =emulator_vsn  9.3.3.5
    =emulator      beam
    =otp_release   20
    =started       2018-11-08 20:34:53
    === TEST COMPLETE, 0 ok, 0 failed of 0 test cases

    =finished      2018-11-08 20:34:53
    =failed        0
    =successful    0
    =user_skipped  0
    =auto_skipped  0

The problem is that only as root will the `=user` key have no value
whatsoever, which, because of how it is parsed, will result in a
structure of the form `{<<"user">>}` due to splitting matches with
regexes and turning them into tuples.

This patch addresses this by expanding them to default to `<<>>` (empty
string) when no value is specified